### PR TITLE
chore: rebrand domain — maxwi.com → yulong.wang

### DIFF
--- a/colorname/index.html
+++ b/colorname/index.html
@@ -13,7 +13,7 @@
 </head>
   <body>
   	<p align="center">
-  		<a href="http://maxwi.com">Maxwi</a>
+  		<a href="http://yulong.wang">yulong.wang</a>
   	</p>
     <p  id = "name_body">
     <canvas id="myCanvas"></canvas>

--- a/colorname/js/main.js
+++ b/colorname/js/main.js
@@ -1,4 +1,4 @@
-var myName = "Maxwi.com";
+var myName = "yulong.wang";
 
 var red = [0, 100, 63];
 var orange = [40, 100, 60];

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Yulong Wang — personal homepage. Notes, code, and contact." />
     <meta name="theme-color" content="#0a0a0f" />
-    <title>Yulong · maxwi</title>
+    <title>Yulong · yulong.wang</title>
     <link rel="icon" href="favicon.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -295,7 +295,7 @@
     <header class="topbar">
         <div class="brand">
             <span class="dot" aria-hidden="true"></span>
-            <span>maxwi.com</span>
+            <span>yulong.wang</span>
         </div>
         <div class="status"><span class="live">●</span> available for work</div>
     </header>
@@ -310,13 +310,13 @@
         </p>
 
         <nav class="links" aria-label="Personal links">
-            <a class="link" href="http://notes.maxwi.com" target="_blank" rel="noopener">
+            <a class="link" href="http://notes.yulong.wang" target="_blank" rel="noopener">
                 <span class="icon" aria-hidden="true">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h11l5 5v11a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"/><path d="M14 4v6h6"/><path d="M7 14h8M7 18h6"/></svg>
                 </span>
                 <span class="meta">
                     <span class="label">Notes</span>
-                    <span class="sub">notes.maxwi.com</span>
+                    <span class="sub">notes.yulong.wang</span>
                 </span>
                 <span class="arrow" aria-hidden="true">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7"/><path d="M8 7h9v9"/></svg>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Switch the site over to the **`yulong.wang`** domain by replacing every `maxwi.com` reference across the repo. The `CNAME` file already pointed to `yulong.wang`, so GitHub Pages now serves the new homepage at the new domain.

## Changes

- `index.html`
  - Brand pill: `maxwi.com` → `yulong.wang`
  - Page title: `Yulong · maxwi` → `Yulong · yulong.wang` (for brand consistency)
  - Notes link: `http://notes.maxwi.com` → `http://notes.yulong.wang`
  - Notes sub-label: `notes.maxwi.com` → `notes.yulong.wang`
- `colorname/index.html`
  - Header link: `http://maxwi.com` (text `Maxwi`) → `http://yulong.wang` (text `yulong.wang`)
- `colorname/js/main.js`
  - `var myName = "Maxwi.com"` → `var myName = "yulong.wang"`
- `CNAME` already `yulong.wang` — no change needed.

## Not changed

- `colorname/js/jquery-1.10.2.min.js` contains the substring `maxwi` inside `u.maxWidth` (a CSS property reference inside minified jQuery). That is a false positive and was intentionally left untouched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36ff47cc-c127-4ef9-babf-b850b23c6781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36ff47cc-c127-4ef9-babf-b850b23c6781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

