### PR TITLE
fix(home): keep Notes link on notes.maxwi.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,13 +310,13 @@
         </p>
 
         <nav class="links" aria-label="Personal links">
-            <a class="link" href="http://notes.yulong.wang" target="_blank" rel="noopener">
+            <a class="link" href="http://notes.maxwi.com" target="_blank" rel="noopener">
                 <span class="icon" aria-hidden="true">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h11l5 5v11a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"/><path d="M14 4v6h6"/><path d="M7 14h8M7 18h6"/></svg>
                 </span>
                 <span class="meta">
                     <span class="label">Notes</span>
-                    <span class="sub">notes.yulong.wang</span>
+                    <span class="sub">notes.maxwi.com</span>
                 </span>
                 <span class="arrow" aria-hidden="true">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7"/><path d="M8 7h9v9"/></svg>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Revert the Notes link URL and label back to `notes.maxwi.com`. The notes site remains under the `maxwi.com` subdomain, so only the main-site brand domain should be rebranded to `yulong.wang`.

## Changes

- `index.html`
  - `<a class="link" href="http://notes.yulong.wang" ...>` → `<a class="link" href="http://notes.maxwi.com" ...>`
  - `<span class="sub">notes.yulong.wang</span>` → `<span class="sub">notes.maxwi.com</span>`

All other `yulong.wang` references (brand pill, title, etc.) stay as-is.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36ff47cc-c127-4ef9-babf-b850b23c6781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36ff47cc-c127-4ef9-babf-b850b23c6781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

