### PR TITLE
chore(copy): switch site to English except the kept motto

### DIFF
--- a/404/css/style.css
+++ b/404/css/style.css
@@ -67,9 +67,9 @@ i{
 	font-size: 24px;
 	font-family: "Microsoft YaHei";
 	font-style: normal;
-	-webkit-animation-duration: 1.4s;/*动画持续时间*/
-    -webkit-animation-iteration-count: 1;/*定义循环资料，infinite为无限次*/
-    -webkit-animation-timing-function: ease;/*动画频率*/
+	-webkit-animation-duration: 1.4s;/* animation duration */
+    -webkit-animation-iteration-count: 1;/* iteration count; "infinite" = endless */
+    -webkit-animation-timing-function: ease;/* animation timing function */
 
     animation-duration: 1.4s;
     animation-iteration-count: 1;

--- a/404/index.html
+++ b/404/index.html
@@ -15,11 +15,11 @@
 			<div id="title"><i>getworld</i><i>.in</i></div>
 		</div>
 		<div class="reason">
-			<p class="not_found_tip">Not Found  :( 很抱歉，您访问的页面不存在!</p>
-			<p class="possible">可能原因：</p>
+			<p class="not_found_tip">Not Found  :(  Sorry, the page you requested does not exist.</p>
+			<p class="possible">Possible reasons:</p>
 			<ul>
-				<li>该链接已被删除，但却被搜索引擎收录了，通过搜索引擎访问就会看到此页面</li>
-				<li>您手动输入了一个从来没有的访问url，这样系统也是无法识别您的url，报错</li>
+				<li>The link has been removed but is still indexed by search engines, so visiting it through a search result lands here.</li>
+				<li>A URL was entered manually that never existed on this site, so the server cannot resolve it.</li>
 			</ul>
 		</div>
 	</div>
@@ -34,8 +34,8 @@
 			<span>4</span>
 		</div>
 		<div class="btn">
-			<a href="http://getworld.in/" class="button button-rounded">看看首页</a>
-			<a href="#" class="button button-rounded cancle">返回上页</a>
+			<a href="http://getworld.in/" class="button button-rounded">Visit homepage</a>
+			<a href="#" class="button button-rounded cancle">Go back</a>
 		</div>   
 	</div>
 	<!-- not_found -->

--- a/index.html
+++ b/index.html
@@ -857,7 +857,7 @@
             <h2>Stack <span class="amp">×</span> Craft</h2>
             <p class="sub">
                 AI Infra · LLM Serving · Agent Systems · GPU / NPU Performance.
-                <span class="zh">从底层 GPU / NPU 性能，到上层 LLM / Agent 系统 — 持续把自己拓展为大模型 &amp; AI Infra 的全栈选手。</span>
+                <span class="zh">From low-level GPU / NPU performance to LLM serving and agent systems — closing the full-stack large-model &amp; AI Infra loop, one release at a time.</span>
             </p>
         </header>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes Chinese text everywhere on the site except the hero motto `心怀善意，虚怀若谷。`, which is kept per request.

## Changes

| File | Before | After |
|---|---|---|
| `index.html` (Stack subline) | `从底层 GPU / NPU 性能，到上层 LLM / Agent 系统 — 持续把自己拓展为大模型 & AI Infra 的全栈选手。` | `From low-level GPU / NPU performance to LLM serving and agent systems — closing the full-stack large-model & AI Infra loop, one release at a time.` |
| `404/index.html` not-found message | `Not Found  :( 很抱歉，您访问的页面不存在!` | `Not Found  :(  Sorry, the page you requested does not exist.` |
| `404/index.html` reasons label | `可能原因：` | `Possible reasons:` |
| `404/index.html` reasons #1 | `该链接已被删除，但却被搜索引擎收录了...` | `The link has been removed but is still indexed by search engines...` |
| `404/index.html` reasons #2 | `您手动输入了一个从来没有的访问url...` | `A URL was entered manually that never existed on this site...` |
| `404/index.html` buttons | `看看首页` / `返回上页` | `Visit homepage` / `Go back` |
| `404/css/style.css` comments | `/*动画持续时间*/` etc. | English equivalents |

## Verification

Final scan for Chinese characters in the repo (excluding `.git`, binaries, minified jQuery):

```
/workspace/index.html:789:            心怀善意，虚怀若谷。
```

Only the kept motto remains.

## Heads-up (not changed here)

The `404/` legacy subdirectory still has `<title>getworld.in</title>` and a `Visit homepage` button linking to `http://getworld.in/` — it appears to be scaffolding from a different site. Worth either deleting `404/` outright or rebuilding it to match the main site's design in a follow-up.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36ff47cc-c127-4ef9-babf-b850b23c6781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36ff47cc-c127-4ef9-babf-b850b23c6781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

