### PR TITLE
ui(resume): hide crypto scheme in modal subtitle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1128,7 +1128,6 @@
         </header>
 
         <p class="modal-sub" id="modal-sub">
-            This resume is encrypted client-side with <code>AES-GCM</code> and a passphrase-derived key (<code>PBKDF2-SHA256</code>, 250k iters).
             Enter the passphrase to decrypt — nothing leaves your browser.
         </p>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Trim the resume-unlock modal subtitle so visitors no longer see the cipher / KDF details.

**Before**
> This resume is encrypted client-side with `AES-GCM` and a passphrase-derived key (`PBKDF2-SHA256`, 250k iters). Enter the passphrase to decrypt — nothing leaves your browser.

**After**
> Enter the passphrase to decrypt — nothing leaves your browser.

The underlying crypto is unchanged — `AES-256-GCM` + `PBKDF2-SHA256` 250k iters remains documented in `README.md` and `tools/README.md` for the site owner / contributors, just not surfaced in the public UI.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36ff47cc-c127-4ef9-babf-b850b23c6781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36ff47cc-c127-4ef9-babf-b850b23c6781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

