### PR TITLE
feat(home): schedule-aware status pill in HKT

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,8 +105,32 @@
             0%, 100% { opacity: 1; transform: scale(1); }
             50%      { opacity: 0.6; transform: scale(0.85); }
         }
-        .status-pill { color: var(--fg-mute); }
-        .status-pill .live { color: var(--good); }
+        .status-pill {
+            color: var(--fg-mute);
+            --state-color: var(--good);
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            cursor: default;
+        }
+        .status-pill.s-green  { --state-color: var(--good); }
+        .status-pill.s-cyan   { --state-color: var(--accent-2); }
+        .status-pill.s-amber  { --state-color: var(--accent-4); }
+        .status-pill.s-purple { --state-color: var(--accent); }
+        .status-pill.s-gray   { --state-color: var(--fg-mute); }
+        .status-pill .live {
+            color: var(--state-color);
+            display: inline-block;
+            line-height: 1;
+            text-shadow: 0 0 6px var(--state-color);
+            animation: pulse 2.4s ease-in-out infinite;
+            transition: color 0.35s ease, text-shadow 0.35s ease;
+        }
+        .status-pill .status-text {
+            transition: opacity 0.35s ease;
+            display: inline-block;
+        }
+        .status-pill.swap .status-text { opacity: 0; }
 
         main {
             display: flex;
@@ -958,7 +982,10 @@
             <span class="dot" aria-hidden="true"></span>
             <span>yulong.wang</span>
         </div>
-        <div class="status-pill"><span class="live">●</span> available for work</div>
+        <div class="status-pill s-green" id="status-pill" title="status follows Hong Kong wall-clock time, refreshed every minute">
+            <span class="live" aria-hidden="true">●</span>
+            <span class="status-text" id="status-text">available for work</span>
+        </div>
     </header>
 
     <main>
@@ -1359,6 +1386,57 @@
     'use strict';
     var y = document.getElementById('year');
     if (y) y.textContent = new Date().getFullYear();
+
+    /* ---------------- Schedule-aware status pill (HKT) ---------------- */
+    (function () {
+        var pill = document.getElementById('status-pill');
+        var text = document.getElementById('status-text');
+        if (!pill || !text) return;
+
+        var WAKE_WEEKDAY_HM = '08:00';
+        var WAKE_WEEKEND_HM = '09:00';
+
+        function hktNow() {
+            /* Hong Kong is UTC+8 year-round (no DST). Shift UTC by +8h and read UTC accessors. */
+            var shifted = new Date(Date.now() + 8 * 3600 * 1000);
+            return {
+                hour:   shifted.getUTCHours(),
+                minute: shifted.getUTCMinutes(),
+                day:    shifted.getUTCDay()  /* 0=Sun, 1=Mon, ..., 6=Sat */
+            };
+        }
+
+        function pickState(h) {
+            var weekend = (h.day === 0 || h.day === 6);
+            if (weekend) {
+                if (h.hour >= 9 && h.hour < 22)        return { text: 'weekend · slow replies',    cls: 's-amber' };
+                if (h.day === 0 && h.hour >= 22)       return { text: 'offline · back monday',     cls: 's-gray'  };
+                return { text: 'offline · back ' + WAKE_WEEKEND_HM + ' HKT', cls: 's-gray' };
+            }
+            if (h.hour >= 8 && h.hour < 22)            return { text: 'online · HKT',              cls: 's-green' };
+            if (h.hour >= 22)                          return { text: 'wrapping up · HKT',         cls: 's-cyan'  };
+            return { text: 'offline · back ' + WAKE_WEEKDAY_HM + ' HKT', cls: 's-gray' };
+        }
+
+        var lastText = null;
+        function apply() {
+            var state = pickState(hktNow());
+            if (state.text === lastText) return;
+            lastText = state.text;
+            /* Brief fade-swap so changes feel intentional, not jumpy. */
+            pill.classList.add('swap');
+            setTimeout(function () {
+                pill.classList.remove('s-green','s-cyan','s-amber','s-purple','s-gray');
+                pill.classList.add(state.cls);
+                text.textContent = state.text;
+                pill.classList.remove('swap');
+            }, 280);
+        }
+
+        apply();
+        setInterval(apply, 60 * 1000); /* re-evaluate every minute */
+    })();
+
 
     /* Scroll reveal for AI section */
     var section = document.querySelector('.afterlinks');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replace the static `available for work` string in the topbar with a self-updating state machine driven by **Hong Kong wall-clock time** (UTC+8, no DST). The pill re-evaluates every 60 s and fades smoothly between states.

## State table

| When (HKT) | Dot | Text |
|---|---|---|
| Mon–Fri **08:00–22:00** | 🟢 green | `online · HKT` |
| Mon–Fri **22:00–24:00** | 🔵 cyan | `wrapping up · HKT` |
| Mon–Fri **00:00–08:00** | ⚪ gray | `offline · back 08:00 HKT` |
| Sat / Sun **09:00–22:00** | 🟡 amber | `weekend · slow replies` |
| Sat **22–24** / Sun **00–09** / Sat **00–09** | ⚪ gray | `offline · back 09:00 HKT` |
| Sun **22:00–24:00** | ⚪ gray | `offline · back monday` |

Right now (Sun 02:00 UTC → Sun 10:00 HKT) the pill should be showing **amber · weekend · slow replies**.

## Implementation notes

- **Zero dependencies.** Time is computed by shifting `Date.now()` by +8 h and reading via UTC accessors — robust to the visitor's local timezone and any DST in their locale.
- New state classes `.s-green` / `.s-cyan` / `.s-amber` / `.s-gray` / `.s-purple` flip a single `--state-color` custom property. The live dot picks it up via `color` + `text-shadow` and keeps its existing pulse animation.
- 280 ms fade-swap on each transition so the change feels intentional, not jittery.
- Text node wrapped in `<span class="status-text" id="status-text">…</span>` so JS swaps content without touching the dot or the pulse.
- Title tooltip: *"status follows Hong Kong wall-clock time, refreshed every minute"*.

## Verification

- Dry-run of `pickState()` across every weekday × 11 sample hours: state grid matches the table above; no off-by-one at the 08/09/22 boundaries.
- `GET /` → 200 (81 KB).
- HTML tag balance: clean.
- Inline JS: `node --check` OK.

## Easy follow-ups (not in this PR)

- Tweak `WAKE_WEEKDAY_HM` / `WAKE_WEEKEND_HM` constants if you want different "online" windows.
- Add a one-off override (e.g. a `data-status="vacation"` attribute or a small "manual override" branch) when you want to pin a state for travel / interviews / etc.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36ff47cc-c127-4ef9-babf-b850b23c6781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36ff47cc-c127-4ef9-babf-b850b23c6781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

