### PR TITLE
ui(home): remove guide attribution pill

### DIFF
--- a/index.html
+++ b/index.html
@@ -404,48 +404,6 @@
             max-width: 740px;
         }
         .section-header .sub .zh { color: var(--fg); }
-        .guide-ref {
-            margin-top: 16px;
-            display: inline-flex;
-            flex-wrap: wrap;
-            align-items: center;
-            gap: 10px;
-            padding: 8px 12px;
-            background: rgba(255,255,255,0.025);
-            border: 1px solid var(--border);
-            border-radius: 10px;
-            font-family: 'JetBrains Mono', ui-monospace, monospace;
-            font-size: 11.5px;
-            color: var(--fg-dim);
-            letter-spacing: 0.04em;
-        }
-        .guide-ref .tag {
-            color: var(--accent-3);
-            text-transform: uppercase;
-            letter-spacing: 0.12em;
-            font-size: 10.5px;
-        }
-        .guide-ref a {
-            color: var(--fg);
-            text-decoration: none;
-            border-bottom: 1px dashed var(--border);
-            transition: color 0.2s ease, border-color 0.2s ease;
-            display: inline-flex;
-            align-items: center;
-            gap: 4px;
-        }
-        .guide-ref a:hover {
-            color: var(--accent-2);
-            border-color: var(--accent-2);
-        }
-        .guide-ref a .arrow { color: var(--accent-2); }
-        .guide-ref .layers {
-            color: var(--fg-mute);
-            margin-left: 4px;
-        }
-        @media (max-width: 520px) {
-            .guide-ref .layers { display: none; }
-        }
 
         /* Full-stack journey pipeline */
         .journey {
@@ -1070,14 +1028,6 @@
             <p class="sub">
                 AI Infra · LLM Serving · Agent Systems · GPU / NPU Performance.
                 <span class="zh">From low-level GPU / NPU performance to LLM serving and agent systems — closing the full-stack large-model &amp; AI Infra loop, one release at a time.</span>
-            </p>
-            <p class="guide-ref">
-                <span class="tag">mapped to</span>
-                <a href="http://notes.maxwi.com/2025/02/19/ai/ai-infra-fullstack-learning-guide/" target="_blank" rel="noopener">
-                    AI Infra full-stack learning guide
-                    <span class="arrow" aria-hidden="true">↗</span>
-                </a>
-                <span class="layers" aria-hidden="true">L0 · L1 · L2 · L3 · L4 · L5 · L6 + 3 pillars</span>
             </p>
         </header>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Drop the `MAPPED TO · AI Infra full-stack learning guide ↗` pill from under the Stack × Craft section sub-line, plus the associated `.guide-ref` CSS that no longer has any usage.

The underlying card structure (P1 / P2 / L3 / L4 / L2 / L6 / L1 · L5) is unchanged — only the visible attribution pill goes away.

## Verification

- `GET /` → 200 (79 KB)
- HTML tag balance: clean
- Inline JS: `node --check` OK
- No leftover `guide-ref` / `MAPPED TO` / `fullstack-learning-guide` references in `index.html`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36ff47cc-c127-4ef9-babf-b850b23c6781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36ff47cc-c127-4ef9-babf-b850b23c6781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

